### PR TITLE
Update scrape.js

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -1,12 +1,7 @@
 const xivApi = require('@xivapi/js');
 const fs = require('fs');
 
-const xivKey = process.env.xiv_key;
 
-if (!xivKey) {
-  console.error('No API key present. Make sure to set it as an environment variable: xiv_key');
-  return;
-}
 
 async function sleep(millis) {
   return new Promise(resolve => setTimeout(resolve, millis));
@@ -38,7 +33,7 @@ async function scrapeAction(api, query) {
 
 (async () => {
   const api = new xivApi({
-    private_key: xivKey
+
   });
 
   const skillQuery = {


### PR DESCRIPTION
Feel free to deny it based on security concerns, as I can see both sides of the argument, however, according to the xivapi-js github documentation, a valid API key is no longer needed using that library.  I figured whom ever may have stumbled upon this was not going to be hitting the API, more than 20/req per second threshold, and abusing it, and it might streamline the process.